### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Semantic Release


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/3](https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level under the workflow name or individually for each job) so the `GITHUB_TOKEN` has only the minimal required scopes. For this workflow, the `release` job runs `semantic-release`, which needs to push tags and releases, so it requires `contents: write`. It may also comment on or update pull requests depending on your semantic-release plugins; to keep changes minimal and safe, we can grant `contents: write` and, if needed, `pull-requests: write`. The `manage_version` job reuses another workflow that likely manipulates tags as well, so giving it `contents: write` is reasonable.

The single best way to fix this without changing existing functionality is to add a root-level `permissions` block that applies to all jobs, placed between the `on:` block and `jobs:`. This keeps the configuration DRY and ensures both `release` and `manage_version` use the same least-privilege token. For a minimal, safe starting point compatible with typical semantic-release flows, we can set:
```yaml
permissions:
  contents: write
```
If your semantic-release setup interacts with PRs (e.g., adding comments), you can extend this to:
```yaml
permissions:
  contents: write
  pull-requests: write
```
Since we cannot see other parts of the repo or plugins, we’ll choose the minimal but functional `contents: write`. No imports or extra methods are needed, just the new YAML block in `.github/workflows/release.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
