### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -10,6 +10,9 @@ on:
       AZURE_TENANT_ID:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Terraform Validation and Security


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/4](https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/4)

In general, the fix is to explicitly configure GITHUB_TOKEN permissions using a `permissions:` block, either at the workflow root (to apply to all jobs) or under the specific job. Here, there is a single `validate` job, so the most straightforward and non-disruptive fix is to add a top-level `permissions` block that grants only read access to repository contents, which is sufficient for `actions/checkout` and the rest of the steps that only read code and produce artifacts.

Concretely, edit `.github/workflows/terraform-security-scan.yml` and insert a `permissions:` block near the top (e.g., after the `on:` block and before `jobs:`) with `contents: read`. No additional scopes appear necessary: the job does not interact with PRs, issues, or other resources, and `upload-sarif` only needs to upload an artifact for GitHub’s code scanning; it works with `contents: read`. This preserves existing behavior while tightening the GITHUB_TOKEN scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
