### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,9 @@ on:
       AZURE_TENANT_ID:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   test-ubuntu:
     name: Integration Tests (Ubuntu)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test-ubuntu:


### PR DESCRIPTION
Potential fix for [https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/1](https://github.com/MonsieurDahlstrom/tf-azure-kubernetes/security/code-scanning/1)

To fix the problem, explicitly define a minimal `permissions` block so the `GITHUB_TOKEN` has only the rights needed. Since this workflow only checks out code, caches files, logs into Azure, and runs Terraform tests, it only needs read access to repository contents.

The best, least-disruptive fix is to add a top-level `permissions` section (so it applies to all jobs, including `test-ubuntu`) with `contents: read`. This does not change existing behavior for the steps, because they already only require read access. Concretely, in `.github/workflows/integration-tests.yml`, insert a `permissions:` block after the `on:` section (after line 12 and before line 13), like:

```yaml
permissions:
  contents: read
```

No imports, methods, or additional definitions are required; this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
